### PR TITLE
enable mogrify for query func #2

### DIFF
--- a/sanic_mysql/core.py
+++ b/sanic_mysql/core.py
@@ -26,8 +26,9 @@ class SanicMysql:
         async def _query(sqlstr, args=None):
             async with _mysql.acquire() as conn:
                 async with conn.cursor() as cur:
-                    log.info('mysql query [{}]'.format(cur.mogrify(sqlstr, args)))
-                    await cur.execute(sqlstr, args)
+                    final_str = cur.mogrify(sqlstr, args)
+                    log.info('mysql query [{}]'.format(final_str))
+                    await cur.execute(final_str)
                     value = await cur.fetchall()
                     return value
 

--- a/sanic_mysql/core.py
+++ b/sanic_mysql/core.py
@@ -23,11 +23,11 @@ class SanicMysql:
         _mysql = await create_pool(**_k)
         log.info('opening mysql connection for [pid:{}]'.format(os.getpid()))
 
-        async def _query(sqlstr):
-            log.info('mysql query [{}]'.format(sqlstr))
+        async def _query(sqlstr, args=None):
             async with _mysql.acquire() as conn:
                 async with conn.cursor() as cur:
-                    await cur.execute(sqlstr)
+                    log.info('mysql query [{}]'.format(cur.mogrify(sqlstr, args)))
+                    await cur.execute(sqlstr, args)
                     value = await cur.fetchall()
                     return value
 


### PR DESCRIPTION
Hi there.

I think we can enable the mogrify func of pymysql.
It's more safe than just passing the string