### PR TITLE
Log support to Sanic 0.5.4

### DIFF
--- a/sanic_mysql/core.py
+++ b/sanic_mysql/core.py
@@ -1,15 +1,26 @@
-from sanic.log import log
 from aiomysql import create_pool
 import os
-
+import logging
 
 class SanicMysql:
     def __init__(self, app, mysql_config=None):
         self.app = app
         self.config = mysql_config
+        
+        logging_format = "[%(asctime)s] %(process)d-%(levelname)s "
+        logging_format += "%(module)s::%(funcName)s():l%(lineno)d: "
+        logging_format += "%(message)s"
+
+        logging.basicConfig(
+            format=logging_format,
+            level=logging.DEBUG
+        )
+
+        self.log = logging.getLogger()
 
         if app:
             self.init_app(app=app)
+    
 
     async def start(self, _app, loop):
         _k = dict(loop=loop)
@@ -21,13 +32,13 @@ class SanicMysql:
         _k.update(config)
 
         _mysql = await create_pool(**_k)
-        log.info('opening mysql connection for [pid:{}]'.format(os.getpid()))
+        self.log.info('opening mysql connection for [pid:{}]'.format(os.getpid()))
 
         async def _query(sqlstr, args=None):
             async with _mysql.acquire() as conn:
                 async with conn.cursor() as cur:
                     final_str = cur.mogrify(sqlstr, args)
-                    log.info('mysql query [{}]'.format(final_str))
+                    self.log.info('mysql query [{}]'.format(final_str))
                     await cur.execute(final_str)
                     value = await cur.fetchall()
                     return value
@@ -45,5 +56,5 @@ class SanicMysql:
         @app.listener('after_server_stop')
         async def close_mysql(_app, loop):
             _app.mysql.close()
-            log.info('closing mysql connection for [pid:{}]'.format(os.getpid()))
+            self.log.info('closing mysql connection for [pid:{}]'.format(os.getpid()))
             await _app.mysql.wait_closed()

--- a/sanic_mysql/core.py
+++ b/sanic_mysql/core.py
@@ -6,7 +6,13 @@ class SanicMysql:
     def __init__(self, app, mysql_config=None):
         self.app = app
         self.config = mysql_config
-        
+
+        self.log = self.configLog()
+
+        if app:
+            self.init_app(app=app)
+    
+    def configLog(self):
         logging_format = "[%(asctime)s] %(process)d-%(levelname)s "
         logging_format += "%(module)s::%(funcName)s():l%(lineno)d: "
         logging_format += "%(message)s"
@@ -16,11 +22,7 @@ class SanicMysql:
             level=logging.DEBUG
         )
 
-        self.log = logging.getLogger()
-
-        if app:
-            self.init_app(app=app)
-    
+        return logging.getLogger()
 
     async def start(self, _app, loop):
         _k = dict(loop=loop)


### PR DESCRIPTION
The importing "sanic.log" doesn't work in actual Sanic version, then it is necessary to use "import logging"